### PR TITLE
Step by step

### DIFF
--- a/easypy/lockstep.py
+++ b/easypy/lockstep.py
@@ -1,0 +1,106 @@
+from contextlib import contextmanager
+from functools import wraps
+
+from .exceptions import TException
+
+
+class LockstepSyncMismatch(TException):
+    template = "Expected {lockstep_name} to be {expected_step}, but it is {actual_step}"
+
+
+class _LockstepInvocation(object):
+    def __init__(self, name, generator):
+        self._name = name
+        self._generator = generator
+        self._current_step = 'just-started'
+
+    def step_next(self, step):
+        """Progress to the next step, confirming it's the specified one"""
+
+        try:
+            self._current_step, value = self._next_step_and_value()
+        except StopIteration:
+            raise LockstepSyncMismatch(lockstep_name=self._name,
+                                       expected_step=step,
+                                       actual_step='finished')
+        if self._current_step != step:
+            raise LockstepSyncMismatch(lockstep_name=self._name,
+                                       expected_step=step,
+                                       actual_step=self._current_step)
+        return value
+
+    def step_until(self, step):
+        """Progress until we get to the specified step, confirming that it exist"""
+
+        while self._current_step != step:
+            try:
+                self._current_step, value = self._next_step_and_value()
+            except StopIteration:
+                raise LockstepSyncMismatch(lockstep_name=self._name,
+                                           expected_step=step,
+                                           actual_step='finished')
+        return value
+
+    def step_all(self):
+        """Progress through all the remaining steps"""
+
+        for self._current_step in self._generator:
+            pass
+
+    def _next_step_and_value(self):
+        yield_result = next(self._generator)
+        if isinstance(yield_result, tuple) and len(yield_result) == 2:
+            return yield_result
+        else:
+            return yield_result, None
+
+    def __str__(self):
+        return '%s<%s>' % (self._name, self._current_step)
+
+
+class _LockstepContextManagerWrapper(object):
+    def __init__(self, cm):
+        self._cm = cm
+
+    def __enter__(self):
+        return self._cm.__enter__()
+
+    def __exit__(self, *args):
+        return self._cm.__exit__(*args)
+
+    def __iter__(self):
+        with self._cm as invocation:
+            yield from invocation._generator
+
+
+def lockstep(generator_func):
+    """
+    Synchronize a coroutine that runs a process step-by-step.
+
+    Decorate a generator that yields step names to create a context manager.
+    The context object has a `.step_next`/`.step_until` methods that must be
+    called, in order, with all expected step names, to make the generator
+    progress to each step.
+    """
+
+    @contextmanager
+    def cm(*args, **kwargs):
+        invocation = _LockstepInvocation(generator_func.__name__, generator_func(*args, **kwargs))
+
+        yield invocation
+
+        try:
+            step_not_taken, _ = invocation._next_step_and_value()
+        except StopIteration:
+            # all is well - all steps were exhausted
+            invocation._current_step = 'finished'
+        else:
+            raise LockstepSyncMismatch(lockstep_name=invocation._name,
+                                       expected_step='finished',
+                                       actual_step=step_not_taken)
+
+    @wraps(generator_func)
+    def wrapper(*args, **kwargs):
+        return _LockstepContextManagerWrapper(cm(*args, **kwargs))
+
+    return wrapper

--- a/tests/test_lockstep.py
+++ b/tests/test_lockstep.py
@@ -1,0 +1,159 @@
+import pytest
+
+from easypy.lockstep import lockstep, LockstepSyncMismatch
+
+
+def test_lockstep_side_effects():
+    calculation_result = 0
+
+    @lockstep
+    def simple_calculation(number):
+        nonlocal calculation_result
+
+        calculation_result = number
+        yield 'SET_NUMBER'
+
+        calculation_result *= 2
+        yield 'MULTIPLY_IT_BY_TWO'
+
+        calculation_result += 5
+        yield 'ADD_FIVE'
+
+    with simple_calculation(5) as calculation:
+        calculation.step_next('SET_NUMBER')
+        assert calculation_result == 5
+
+        calculation.step_next('MULTIPLY_IT_BY_TWO')
+        assert calculation_result == 10
+
+        calculation.step_next('ADD_FIVE')
+        assert calculation_result == 15
+
+
+def test_lockstep_wrong_step_name():
+    @lockstep
+    def process():
+        yield 'STEP_1'
+        yield 'STEP_2'
+        yield 'STEP_3'
+
+    with pytest.raises(LockstepSyncMismatch) as excinfo:
+        with process() as process:
+            process.step_next('STEP_1')
+            process.step_next('STEP_TWO')
+            process.step_next('STEP_3')
+
+    assert excinfo.value.expected_step == 'STEP_TWO'
+    assert excinfo.value.actual_step == 'STEP_2'
+
+
+def test_lockstep_not_exhausted():
+    @lockstep
+    def process():
+        yield 'STEP_1'
+        yield 'STEP_2'
+        yield 'STEP_3'
+
+    with pytest.raises(LockstepSyncMismatch) as excinfo:
+        with process() as process:
+            process.step_next('STEP_1')
+            process.step_next('STEP_2')
+
+    assert excinfo.value.expected_step == 'finished'
+    assert excinfo.value.actual_step == 'STEP_3'
+
+
+def test_lockstep_exhausted_prematurely():
+    @lockstep
+    def process():
+        yield 'STEP_1'
+        yield 'STEP_2'
+
+    with pytest.raises(LockstepSyncMismatch) as excinfo:
+        with process() as process:
+            process.step_next('STEP_1')
+            process.step_next('STEP_2')
+            process.step_next('STEP_3')
+
+    assert excinfo.value.expected_step == 'STEP_3'
+    assert excinfo.value.actual_step == 'finished'
+
+
+def test_lockstep_exhaust():
+    finished = False
+
+    @lockstep
+    def process():
+        nonlocal finished
+
+        yield 'STEP_1'
+        yield 'STEP_2'
+        yield 'STEP_3'
+
+        finished = True
+
+    assert not finished
+    with process() as process:
+        assert not finished
+        process.step_all()
+        assert finished
+    assert finished
+
+
+def test_lockstep_yielded_values():
+    @lockstep
+    def process():
+        yield 'STEP_1', 1
+        yield 'STEP_2'
+        yield 'STEP_3', 3
+
+    with process() as process:
+        assert process.step_next('STEP_1') == 1
+        assert process.step_next('STEP_2') is None
+        assert process.step_next('STEP_3') == 3
+
+
+def test_lockstep_nested():
+    @lockstep
+    def internal_process():
+        yield 'INTERNAL_1'
+        yield 'INTERNAL_2'
+
+    @lockstep
+    def external_process():
+        yield 'EXTERNAL_1'
+        yield from internal_process()
+        yield 'EXTERNAL_2'
+
+    with external_process() as process:
+        process.step_next('EXTERNAL_1')
+        process.step_next('INTERNAL_1')
+        process.step_next('INTERNAL_2')
+        process.step_next('EXTERNAL_2')
+
+
+def test_lockstep_step_util():
+    @lockstep
+    def process():
+        yield 'STEP_1'
+        yield 'STEP_2'
+        yield 'STEP_3'
+
+    with process() as process:
+        process.step_until('STEP_3')
+
+
+def test_lockstep_step_util_wrong_order():
+    @lockstep
+    def process():
+        yield 'STEP_1'
+        yield 'STEP_2'
+        yield 'STEP_3'
+
+    with pytest.raises(LockstepSyncMismatch) as excinfo:
+        with process() as process:
+            process.step_until('STEP_2')
+            process.step_until('STEP_1')
+
+    assert excinfo.value.expected_step == 'STEP_1'
+    assert excinfo.value.actual_step == 'finished'


### PR DESCRIPTION
@koreno - I want to use this for the installation tests. Instead of using a bare generator and hoping we counted the `yield`s and and `next` correctly and in sync, a `step_by_step` will allow us to enforce that the installation step the test thinks we are at is the same step the infra says we are at.