### PR TITLE
Add `deprecated_arguments` decorator.

### DIFF
--- a/easypy/decorations.py
+++ b/easypy/decorations.py
@@ -22,6 +22,42 @@ def deprecated(func=None, message=None):
     return inner
 
 
+def deprecated_arguments(**argmap):
+    def wrapper(func):
+        """
+        Renames arguments while emitting deprecation warning
+
+        @deprecated_arguments(old_name='new_name')
+        def func(new_name):
+            # ...
+
+        func(old_name='value meant for new name')
+        """
+
+        @wraps(func)
+        def inner(*args, **kwargs):
+            deprecation_warnings = []
+            for name, map_to in argmap.items():
+                try:
+                    value = kwargs.pop(name)
+                except KeyError:
+                    pass  # deprecated argument was not used
+                else:
+                    if map_to in kwargs:
+                        raise TypeError("%s is deprecated for %s - can't use both in %s()" % (
+                                        name, map_to, func.__name__))
+                    deprecation_warnings.append('%s is deprecated - use %s instead' % (name, map_to))
+                    kwargs[map_to] = value
+
+            if deprecation_warnings:
+                message = 'Hey! In %s, %s' % (func.__name__, ', '.join(deprecation_warnings))
+                warnings.warn(message, DeprecationWarning, stacklevel=2)
+
+            return func(*args, **kwargs)
+        return inner
+    return wrapper
+
+
 def parametrizeable_decorator(deco):
     @wraps(deco)
     def inner(func=None, **kwargs):

--- a/tests/test_decorations.py
+++ b/tests/test_decorations.py
@@ -1,0 +1,17 @@
+import pytest
+
+from easypy.decorations import deprecated_arguments
+
+
+def test_deprecated_arguments():
+    @deprecated_arguments(foo='bar')
+    def func(bar):
+        return 'bar is %s' % (bar,)
+
+    assert func(1) == func(foo=1) == func(bar=1) == 'bar is 1'
+
+    with pytest.raises(TypeError):
+        func(foo=1, bar=2)
+
+    with pytest.raises(TypeError):
+        func(1, foo=2)


### PR DESCRIPTION
We can use `@deprecated` to safely rename functions and fix calls to
them based on the deprecation warnings. This decorator does the same
thing for function arguments.