### PR TITLE
Add `late_decorator` - run decorator in objects instead of classes

### DIFF
--- a/easypy/decorations.py
+++ b/easypy/decorations.py
@@ -5,6 +5,7 @@ from functools import wraps, partial
 from types import MethodType
 import warnings
 from threading import RLock
+from operator import attrgetter
 
 from easypy.collections import intersected_dict
 
@@ -176,3 +177,47 @@ def as_list(generator, sort_by=None):
             l.sort(key=sort_by)
         return l
     return inner
+
+
+class LateDecoratorDescriptor:
+    def __init__(self, decorator_factory, func):
+        self.decorator_factory = decorator_factory
+        self.func = func
+
+    def __get__(self, instance, owner):
+        method = self.func.__get__(instance, owner)
+        if instance is None:
+            return method
+        else:
+            decorator = self.decorator_factory(instance)
+            return decorator(method)
+
+
+def late_decorator(decorator_factory):
+    """
+    Create and apply a decorator only after the method is instantiated.
+
+    class UsageWithLambda:
+        @late_decorator(lambda self: some_decorator_that_needs_the_object(self))
+        def foo(self):
+            # ...
+
+    class UsageWithAttribute:
+        def decorator_method(self, func):
+            # ...
+
+        @late_decorator('decorator_method')
+        def foo(self):
+            # ...
+    """
+
+    if callable(decorator_factory):
+        pass
+    elif isinstance(decorator_factory, str):
+        decorator_factory = attrgetter(decorator_factory)
+    else:
+        raise TypeError('decorator_factory must be callable or string, not %s' % type(decorator_factory))
+
+    def wrapper(func):
+        return LateDecoratorDescriptor(decorator_factory, func)
+    return wrapper

--- a/tests/test_decorations.py
+++ b/tests/test_decorations.py
@@ -1,6 +1,8 @@
 import pytest
 
-from easypy.decorations import deprecated_arguments
+from functools import wraps
+
+from easypy.decorations import deprecated_arguments, parametrizeable_decorator, late_decorator
 
 
 def test_deprecated_arguments():
@@ -15,3 +17,64 @@ def test_deprecated_arguments():
 
     with pytest.raises(TypeError):
         func(1, foo=2)
+
+
+def test_late_decorator_lambda():
+    @parametrizeable_decorator
+    def add_to_result(func, num):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            return func(*args, **kwargs) + num
+
+        wrapper.__name__ = '%s + %s' % (func.__name__, num)
+
+        return wrapper
+
+    class Foo:
+        def __init__(self, num):
+            self.num = num
+
+        @late_decorator(lambda self: add_to_result(num=self.num))
+        def foo(self):
+            """foo doc"""
+            return 1
+
+    foo = Foo(10)
+    assert foo.foo() == 11
+
+    assert Foo.foo.__name__ == 'foo'
+    assert foo.foo.__name__ == 'foo + 10'
+
+    assert Foo.foo.__doc__ == foo.foo.__doc__ == 'foo doc'
+
+
+def test_late_decorator_attribute():
+    class Foo:
+        def add_to_result(self, func):
+            @wraps(func)
+            def wrapper(*args, **kwargs):
+                return func(*args, **kwargs) + self.num
+
+            wrapper.__name__ = '%s + %s' % (func.__name__, self.num)
+
+            return wrapper
+
+        @late_decorator('add_to_result')
+        def foo(self):
+            """foo doc"""
+            return 1
+
+    foo = Foo()
+
+    with pytest.raises(AttributeError):
+        # We did not set foo.num yet, so the decorator will fail trying to set the name
+        foo.foo
+
+    foo.num = 10
+    assert foo.foo() == 11
+    assert foo.foo.__name__ == 'foo + 10'
+    assert Foo.foo.__doc__ == foo.foo.__doc__ == 'foo doc'
+
+    foo.num = 20
+    assert foo.foo() == 21
+    assert foo.foo.__name__ == 'foo + 20'


### PR DESCRIPTION
I've encountered several situations in the past where this decorator could be useful. The most recent one is @navotsil's big cluster PR. With this, `CACHE_TIMESTAMPS` and friends can be bundled in a class that will be part of `WekaSystem`, and we can use late decorators to easily use the methods of that class as decorators for `WekaSystem` properties.