### PR TITLE
bunch: fix checks in bunch when KEYS is set

### DIFF
--- a/easypy/bunch.py
+++ b/easypy/bunch.py
@@ -40,17 +40,17 @@ class Bunch(dict):
         return self
 
     def __delitem__(self, key):
-        if key in self.KEYS:
+        if self.KEYS and key in self.KEYS:
             raise CannotDeleteRequiredKey(_required=key)
         super().__delitem__(key)
 
     def __setitem__(self, key, value):
-        if key in self.KEYS:
+        if self.KEYS and key not in self.KEYS:
             raise KeyNotAllowed(_disallowed=key)
         super().__setitem__(key, value)
 
     def pop(self, key, *args):
-        if key in self.KEYS:
+        if self.KEYS and key in self.KEYS:
             raise CannotDeleteRequiredKey(_required=key)
         return super().pop(key, *args)
 

--- a/tests/test_bunch.py
+++ b/tests/test_bunch.py
@@ -32,12 +32,15 @@ def test_required_keys():
     x = RB(a='a', b='b', c='c')
     assert 'a' in x
     assert x['b']
-    assert x['c']
+    x.c = 'C'
 
     x = RB.fromkeys("abc", True)
     assert 'a' in x
     assert x['b']
-    assert x['c']
+    x.c = 'C'
+
+    with pytest.raises(KeyNotAllowed):
+        x.d = 'd'
 
     with pytest.raises(CannotDeleteRequiredKey):
         x.pop("a")


### PR DESCRIPTION
`__setitem__` in `Bunch` checks the opposite of what we want. Fixing that fails other stuff because we should only check if `KEYS` is set.
Also added assignment tests to uts.