### PR TITLE
Allow filtering by nested attributes

### DIFF
--- a/easypy/collections.py
+++ b/easypy/collections.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 import collections
 from numbers import Integral
 from itertools import chain, islice
-from functools import partial
+from functools import partial, reduce
 import random
 from .predicates import make_predicate
 from .tokens import UNIQUE
@@ -42,10 +42,17 @@ class defaultlist(list):
 
 
 def _get_value(obj, attr):
-    value = getattr(obj, attr)
-    if callable(value):
-        value = value()
-    return value
+    try:
+        value = getattr(obj, attr)
+    except AttributeError:
+        parts = attr.split('__')
+        if len(parts) == 1:
+            raise
+        return reduce(_get_value, parts, obj)
+    else:
+        if callable(value):
+            value = value()
+        return value
 
 
 def _validate(obj, key, value):

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -17,6 +17,13 @@ def test_collection_filter():
     assert l.filtered(lambda c: c == 'a').sample(1) == ['a']
 
 
+def test_collection_nested_filter():
+    l = ListCollection([Bunch(a=Bunch(b=1, c=2)),
+                        Bunch(a=Bunch(b=2, c=2))])
+    assert list(l.filtered(a__b=1)) == [l[0]]
+    assert list(l.filtered(a__c=2)) == [l[0], l[1]]
+
+
 def test_partial_dict():
     assert partial_dict({'a': 1, 'b': 2, 'c': 3}, ['a', 'b']) == {'a': 1, 'b': 2}
 


### PR DESCRIPTION
Motivation - easier filtering without lambdas/helper methods. Mostly useful for filtering by capabilities. Examples:

* We have this line:
    ```python
    all_hosts = all_hosts.filtered(user_app=True)
    ```
    But it requires to declare:
    ```python
    @property
    def user_app(self):
        return self.capabilities.user_app.relevant
    ```
    Now we can just:
    ```python
    all_hosts = all_hosts.filtered(capabilities__user_app=True)
    # No special method required
    ```

* We have this line:
    ```python
    return self.progress_timestamp_for(self.system.hosts.filtered(lambda h: h.capabilities.events.works))
    ```
    Now we can just:
    ```python
    return self.progress_timestamp_for(self.system.hosts.filtered(capabilities__events__works=True))
    ```
