### PR TITLE
Allow `iter_wait` to handle long predicates

### DIFF
--- a/easypy/timing.py
+++ b/easypy/timing.py
@@ -277,11 +277,12 @@ def iter_wait(timeout, pred=None, sleep=0.5, message=None,
 
         while True:
             s_timer = Timer()
+            expired = l_timer.expired
             ret = pred()
             if ret not in (None, False):
                 yield ret
                 return
-            if l_timer.expired:
+            if expired:
                 duration = l_timer.stop()
                 if throw:
                     raise TimeoutException(message, duration=duration)

--- a/tests/test_timing.py
+++ b/tests/test_timing.py
@@ -78,3 +78,21 @@ def test_iter_wait_progress_total_timeout():
         for state in iter_wait_progress(get, advance_timeout=1, sleep=.05, total_timeout=.1):
             pass
     assert exc.value.message.startswith("advanced but failed to finish")
+
+
+def test_wait_long_predicate():
+    """
+    After the actual check the predicate is held for 3 seconds. Make sure
+    that we don't get a timeout after 2 seconds - because the actual
+    condition should be met in 1 second!
+    """
+
+    t = Timer()
+
+    def pred():
+        try:
+            return 1 < t.duration
+        finally:
+            wait(3)
+
+    wait(2, pred)


### PR DESCRIPTION
Basically this moves the expiration check to before running the
predicate, to avoid the following scenario:

1. Predicate checks the condition.
2. Something the predicate function does after that takes very long.
3. Some times passes.
4. The actual condition becomes true(not checked yet)
5. Some more time passes.
6. The predicate function finishes whatever it was doing and returns.
7. TIMEOUT!

This change makes sure that no matter how long the predicate takes, as
long as the condition becomes true **before** the expiration time the
predicate will have a chance to check it and return True.