### PR TITLE
Close #38: Add `TypedStruct`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ python:
   - "3.5-dev" # 3.5 development branch
   - "3.6"
   - "3.6-dev" # 3.6 development branch
-  - "3.7-dev" # 3.7 development branch
-  - "nightly" # currently points to 3.7-dev
+  # - "3.7-dev" # 3.7 development branch
+  # - "nightly" # currently points to 3.7-dev
 env:
   - GEVENT=true
   - GEVENT=false

--- a/easypy/humanize.py
+++ b/easypy/humanize.py
@@ -597,7 +597,8 @@ def ipython_mapping_repr(mapping, p, cycle):
     if cycle:
         p.text('%s(...)' % mapping.__class__.__name__)
         return
-    with p.group(6, '%s(' % mapping.__class__.__name__, ')'):
+    prefix = '%s(' % mapping.__class__.__name__
+    with p.group(len(prefix), prefix, ')'):
         for idx, (k, v) in enumerate(sorted(mapping.items())):
             if idx:
                 p.text(',')

--- a/easypy/typed_struct.py
+++ b/easypy/typed_struct.py
@@ -1,0 +1,407 @@
+from copy import deepcopy
+
+from .exceptions import TException
+from .tokens import MANDATORY
+from .collections import ListCollection, PythonOrderedDict
+from .bunch import Bunch, bunchify
+
+
+class InvalidFieldType(TException):
+    template = 'Bad field type {field_type} - {reason}'
+
+
+class NotFields(TException, AttributeError):
+    template = '{field_names} are not fields of {typed_struct.__name__}'
+
+
+class NotAField(TException, AttributeError):
+    template = '{field_name} is not a field of {typed_struct.__name__}'
+
+
+class NotAKey(TException, KeyError):
+    template = '{field_name} is not a key of {typed_struct.__name__}'
+
+
+class MissingField(TException, TypeError):
+    template = '{typed_struct.__name__} is missing mandatory field {field.name}'
+
+
+class FieldTypeMismatch(TException, TypeError):
+    template = '{field.name} is {expected_type}, not {received_type}'
+
+
+class FieldKeyTypeMismatch(TException, TypeError):
+    template = 'keys of {field.name} are {expected_type}, not {received_type}'
+
+
+class Field(object):
+    """
+    Define a single field in a TypedStruct
+
+        type: The type of the field
+              * Use [<type>] for a typechecked list
+              * Use {<key_type>: <type>} for a typechecked dict
+              * Use {str: <type>} for a typechecked Bunch
+        default: Default value for the field
+        preprocess: A function for preprocessing the values assigned to the field:
+                    * If the field can be converted from different types,
+                      should do the conversion and return the converted value.
+                    * If there are validation checks, should perform them and
+                      raise an exception if they fail.
+                    * Use the field.add_validation() and field.add_conversion()
+                      helpers to modify the preprocess function without
+                      manually setting this parameter.
+                    * Must return a value of the field's type.
+        meta: Custom metadata. Can be queried by tools that use reflection on
+              the TypedStruct object.
+    """
+
+    def __init__(self, type, *, default=MANDATORY, preprocess=None, meta=Bunch()):
+        if isinstance(type, list):
+            if len(type) != 1:
+                raise InvalidFieldType(field_type=type,
+                                       reason='Collection-style fields must be defined with a single item collection')
+            type, = type
+            self.collection_type = TypedList
+            self.key_type = None
+        elif isinstance(type, dict):
+            if len(type) != 1:
+                raise InvalidFieldType(field_type=type,
+                                       reason='Collection-style fields must be defined with a single item collection')
+            (self.key_type, type), = type.items()
+            if self.key_type is str:
+                self.collection_type = TypedBunch
+            else:
+                self.collection_type = TypedDict
+        else:
+            self.collection_type = None
+            self.key_type = None
+
+        import builtins
+        if not isinstance(type, builtins.type):
+            raise InvalidFieldType(field_type=type,
+                                   reason='Not a type')
+        self.type = type
+
+        self.default = default
+        # NOTE: _validate_type() will be also be called in _process_new_value()
+        # in case people implement their own preprocess function, but we still
+        # want to call it before the validatiors added with add_validation() so
+        # that they won't throw a generic TypeError that will prevent the more
+        # specific FieldTypeMismatch.
+        self.preprocess = preprocess or self._validate_type
+        self.meta = Bunch(meta)
+        self.name = None
+
+        if issubclass(self.type, TypedStruct):
+            if self.default is MANDATORY:
+                try:
+                    self.default = self.type()
+                except MissingField:
+                    pass  # keep it mandatory
+
+            orig_preprocess = self.preprocess
+
+            def preprocess(obj):
+                if isinstance(obj, dict) and not isinstance(obj, TypedStruct):
+                    obj = self.type.from_dict(obj)
+                return orig_preprocess(obj)
+            self.preprocess = preprocess
+
+    def add_validation(self, predicate, ex_type, *ex_args, **ex_kwargs):
+        """
+        Add a validation on values assigned to the field
+
+            predicate: The validation function. Should return True if the value is OK.
+            ex_type: The exception to raise if the predicate returns False on a value.
+            ex_args, ex_kwargs: Arguments for the exception.
+
+        Calling this method will modify the preprocess function.
+        """
+        orig_preprocess = self.preprocess
+
+        def new_preprocess(obj):
+            obj = orig_preprocess(obj)
+            if not predicate(obj):
+                raise ex_type(*ex_args, **ex_kwargs)
+            return obj
+        self.preprocess = new_preprocess
+
+    def add_conversion(self, predicate, conversion):
+        """
+        Add a validation on values assigned to the field
+
+            predicate: Only perform the conversion if this returns True.
+            conversion: A conversion function. The returned value must be of
+                        the type of the field.
+
+        Calling this method will modify the preprocess function.
+        """
+        if isinstance(predicate, type):
+            typ = predicate
+
+            def predicate(obj):
+                return isinstance(obj, typ)
+
+        orig_preprocess = self.preprocess
+
+        def new_preprocess(obj):
+            if predicate(obj):
+                obj = conversion(obj)
+                assert isinstance(obj, self.type), 'Conversion %s converted to %s - expected %s' % (
+                    conversion, type(obj), self.type)
+            return orig_preprocess(obj)
+        self.preprocess = new_preprocess
+
+    def _validate_type(self, value):
+        if not isinstance(value, self.type):
+            raise FieldTypeMismatch(field=self,
+                                    expected_type=self.type,
+                                    received_type=type(value)) from None
+        return value
+
+    def _named(self, name):
+        assert self.name is None, '%s is already named' % self
+        self.name = name
+        return self
+
+    def __get__(self, obj, _=None):
+        if obj is None:
+            return self
+        return obj[self.name]
+
+    def __set__(self, obj, value):
+        if self.collection_type is not None:
+            try:
+                existing = obj[self.name]
+            except KeyError:  # First time - called from TypedStruct c'tor
+                assert isinstance(value, self.collection_type), '%s is not a %s' % (value, self.collection_type)
+            else:  # Collection already exists - let it handle the assignment
+                if existing is not value:
+                    existing._set(value)
+                return
+
+        else:
+            value = self._process_new_value(value)
+
+        return super(TypedStruct, obj).__setitem__(self.name, value)
+
+    def _process_new_value(self, value):
+        value = self.preprocess(value)
+        self._validate_type(value)
+        return value
+
+
+class TypedCollection(object):
+    def __init__(self, owner, field):
+        self._owner = owner
+        self._field = field
+        super().__init__()
+
+
+class TypedList(TypedCollection, ListCollection):
+    def _set(self, values):
+        # Must eagerly verify them all before clearing the list
+        values = [self._field._process_new_value(value) for value in values]
+        self.clear()
+        # Use super to avoid calling _process_new_value twice
+        super().extend(values)
+
+    def __setitem__(self, index, value):
+        value = self._field._process_new_value(value)
+        return super().__setitem__(index, value)
+
+    def append(self, value):
+        value = self._field._process_new_value(value)
+        return super().append(value)
+
+    def insert(self, index, value):
+        value = self._field._process_new_value(value)
+        return super().insert(index, value)
+
+    def __iadd__(self, other):
+        other = map(self._field._process_new_value, other)
+        return super().__iadd__(other)
+
+    def extend(self, iterable):
+        iterable = map(self._field._process_new_value, iterable)
+        return super().extend(iterable)
+
+    # TODO: We may decide to override these methods in the future. They don't
+    # need to validate members, but do change the collection - so if we want to
+    # add events we need to override them:
+    #       __delitem__(self, key)
+    #       __imul__(self, other)
+    #       clear(self)
+    #       remove(self, value)
+    #       reverse(self)
+    #       sort(self, key=None, reverse=False)
+    #       pop(self, index=None)
+
+
+class TypedDict(TypedCollection, dict):
+    def _set(self, values):
+        # Must eagerly verify them all before clearing the list
+        values = {self._process_new_key(k): self._field._process_new_value(v) for k, v in values.items()}
+        self.clear()
+        # # Use super to avoid calling _process_new_value twice
+        super().update(values)
+
+    def _process_new_key(self, key):
+        if not isinstance(key, self._field.key_type):
+            raise FieldKeyTypeMismatch(field=self._field,
+                                       expected_type=self._field.key_type,
+                                       received_type=type(key))
+        return key
+
+    def __setitem__(self, key, value):
+        key = self._process_new_key(key)
+        value = self._field._process_new_value(value)
+        return super().__setitem__(key, value)
+
+    def setdefault(self, key, default=None):
+        key = self._process_new_key(key)
+        default = self._field._process_new_value(default)
+        return super().setdefault(key, default)
+
+    def update(self, dct={}, **kwargs):
+        try:
+            items = dct.items
+        except AttributeError:
+            items = dct
+        else:
+            items = items()
+
+        for k, v in items:
+            self[k] = v
+
+        for k, v in kwargs.items():
+            self[k] = v
+
+    # TODO: We may decide to override these methods in the future. They don't
+    # need to validate members, but do change the collection - so if we want to
+    # add events we need to override them:
+    #       __delitem__(self, key)
+    #       clear(self)
+    #       pop(k[,d])
+    #       popitem(self)
+
+
+class TypedBunch(TypedDict, Bunch):
+    def __init__(self, owner, field):
+        # Hack around Bunch's __getattr__()
+        self.__dict__.update(_field=field, _owner=owner)
+
+
+TypedBunch.__name__ = 'Bunch'  # make it look like a Bunch when formatted
+
+
+class TypedStructMeta(type):
+    @classmethod
+    def __prepare__(metacls, name, bases, **kwds):
+        return PythonOrderedDict()
+
+    def __new__(cls, name, bases, dct):
+        def altered_dct_gen():
+            fields = []
+            yield '_fields', fields
+            for k, v in dct.items():
+                if isinstance(v, Field):
+                    v = v._named(k)
+                    fields.append(v)
+                else:
+                    try:
+                        v = Field(v)._named(k)
+                        fields.append(v)
+                    except InvalidFieldType:
+                        pass
+                yield k, v
+        return super().__new__(cls, name, bases, dict(altered_dct_gen()))
+
+
+class TypedStruct(dict, metaclass=TypedStructMeta):
+    """
+    Define typechecked-at-runtime classes.
+
+    * Define fields with types, defaults values, validators etc.
+    * Nesting of TypedStructs.
+    * Typechecked collections.
+
+    Example:
+
+        import easypy.typed_struct as ts
+
+        class Foo(ts.TypedStruct):
+            a = ts.Field(int, default=14)
+            b = ts.Field([str], default=['1', '2', '3'])  # list of strings
+
+            # Shorter style - less customizable but you get completions
+            c = bool
+            d = [float]
+    """
+
+    @classmethod
+    def _get_field(cls, name, error_variant):
+        field = getattr(cls, name, None)
+        if not isinstance(field, Field):
+            raise error_variant(typed_struct=cls,
+                                field_name=name)
+        return field
+
+    @classmethod
+    def from_dict(cls, dct):
+        return cls(**dct)
+
+    def items(self):
+        for field in self._fields:
+            yield field.name, field.__get__(self)
+
+    def to_dict(self):
+        return {name: value.to_dict() if isinstance(value, TypedStruct) else value
+                for name, value in self.items()}
+
+    def to_bunch(self):
+        return bunchify(self)
+
+    def __init__(self, **kwargs):
+        for field in self._fields:
+            if field.collection_type is not None:
+                value = field.collection_type(self, field)
+                if field.default is not MANDATORY:
+                    value._set(deepcopy(field.default))
+                field.__set__(self, value)
+            else:
+                try:
+                    value = kwargs.pop(field.name)
+                except KeyError:
+                    if field.default is MANDATORY:
+                        raise MissingField(typed_struct=type(self),
+                                           field=field) from None
+                    value = deepcopy(field.default)
+                field.__set__(self, value)
+        if kwargs:
+            raise NotFields(typed_struct=type(self), field_names=', '.join(kwargs.keys()))
+
+    def __delitem__(self, key):
+        assert False, 'deletion is not allowed'
+
+    def __setitem__(self, key, value):
+        self._get_field(key, NotAKey).__set__(self, value)
+
+    def __setattr__(self, name, value):
+        self._get_field(name, NotAField).__set__(self, value)
+
+    def __repr__(self):
+        return '%s(%s)' % (type(self).__name__, ', '.join('%s=%r' % pair for pair in self._fields_and_values()))
+
+    def _repr_pretty_(self, *args, **kwargs):
+        from easypy.humanize import ipython_mapping_repr
+        return ipython_mapping_repr(self, *args, **kwargs)
+
+    def __eq__(self, other):
+        if type(self) != type(other):
+            return False
+        return super().__eq__(other)
+
+    def __ne__(self, other):
+        return not self == other

--- a/tests/test_typed_struct.py
+++ b/tests/test_typed_struct.py
@@ -1,0 +1,439 @@
+import pytest
+
+from easypy.bunch import Bunch
+
+import easypy.typed_struct as ts
+
+
+def test_typed_struct_validations():
+    class OutOfRangeError(Exception):
+        pass
+
+    class Foo(ts.TypedStruct):
+        a = ts.Field(int, default=20)
+        a.add_validation(range(10, 30).__contains__, OutOfRangeError)
+        b = ts.Field(str)
+
+    # Valid construction
+    Foo(b='hi')
+    Foo(a=14, b='hello')
+
+    # Invalid construction
+    with pytest.raises(ts.NotFields) as exc:
+        Foo(b='', c=10)
+    assert exc.value.message == 'c are not fields of Foo'
+
+    with pytest.raises(ts.MissingField) as exc:
+        Foo()
+    assert exc.value.message == 'Foo is missing mandatory field b'
+
+    with pytest.raises(ts.FieldTypeMismatch):
+        Foo(a=20.0, b='')
+
+    with pytest.raises(OutOfRangeError):
+        Foo(a=100, b='')
+
+    foo = Foo(b='')
+
+    # Valid attribute assignments
+    foo.a = 15
+    foo.b = 'hello'
+
+    # Invalid attribute assignments
+    with pytest.raises(ts.NotAField) as exc:
+        foo.c = 10
+    assert exc.value.message == 'c is not a field of Foo'
+
+    with pytest.raises(ts.FieldTypeMismatch):
+        foo.b = []
+
+    with pytest.raises(OutOfRangeError):
+        foo.a = 1000
+
+    assert foo.a == 15
+    assert foo.b == 'hello'
+
+    # Valid key assignments
+    foo['a'] = 25
+    foo['b'] = 'hi'
+
+    # Invalid key assignments
+    with pytest.raises(ts.NotAKey) as exc:
+        foo['c'] = 10
+    assert exc.value.message == 'c is not a key of Foo'
+
+    with pytest.raises(ts.FieldTypeMismatch):
+        foo['b'] = []
+
+    with pytest.raises(OutOfRangeError):
+        foo['a'] = 1000
+
+    assert foo['a'] == 25
+    assert foo['b'] == 'hi'
+
+
+def test_typed_struct_nesting():
+    class Foo(ts.TypedStruct):
+        a = ts.Field(int, default=0)
+        b = ts.Field(int, default=1)
+
+    class Bar(ts.TypedStruct):
+        c = ts.Field(int, default=2)
+        d = ts.Field(int)
+
+    class Baz(ts.TypedStruct):
+        foo = ts.Field(Foo, default=Foo(a=10))
+        foo2 = Foo
+        bar = Bar
+
+    baz = Baz(bar=dict(d=3))
+    assert baz.foo == Foo(a=10, b=1)
+    assert baz.foo2 == Foo()
+    assert baz.bar == Bar(c=2, d=3)
+
+    # Very important - nested fields are modifiable so if the default is used
+    # they must not be shared!
+    assert baz.foo is baz.foo
+    assert baz.foo is not Baz(bar=dict(d=3)).foo
+
+
+def test_typed_struct_comparison():
+    class Foo(ts.TypedStruct):
+        a = int
+        b = int
+
+    class Bar(ts.TypedStruct):
+        a = int
+        b = int
+
+    assert Foo(a=1, b=2) == Foo(a=1, b=2)
+    assert Foo(a=1, b=2) != Foo(a=1, b=3)
+    assert Foo(a=1, b=2) != Bar(a=1, b=2)
+
+    assert Foo(a=1, b=2).to_dict() == Bar(a=1, b=2).to_dict()
+    assert Foo(a=1, b=2).to_bunch() == Bar(a=1, b=2).to_bunch()
+
+
+@pytest.mark.parametrize("use_full_syntax", [True, False])
+def test_typed_struct_list_fields(use_full_syntax):
+    class Foo(ts.TypedStruct):
+        a = int
+
+    if use_full_syntax:
+        class Bar(ts.TypedStruct):
+            foos = ts.Field([Foo])
+            nums = ts.Field([int])
+    else:
+        class Bar(ts.TypedStruct):
+            foos = [Foo]
+            nums = [int]
+
+    bar = Bar()
+    assert bar.foos == []
+
+    # append()
+    bar.foos.append(Foo(a=1))
+    bar.foos.append(dict(a=2))
+    with pytest.raises(ts.FieldTypeMismatch):
+        bar.foos.append(3)
+    assert bar.foos == [Foo(a=1), Foo(a=2)]
+
+    bar.nums.append(1)
+    with pytest.raises(ts.FieldTypeMismatch):
+        bar.nums.append('2')
+    assert bar.nums == [1]
+
+    # __setitem__()
+    bar.foos[0] = Foo(a=4)
+    bar.foos[1] = dict(a=5)
+    with pytest.raises(ts.FieldTypeMismatch):
+        bar.foos[0] = 6
+    assert bar.foos == [Foo(a=4), Foo(a=5)]
+
+    bar.nums[0] = 3
+    assert bar.nums == [3]
+
+    # insert()
+    bar.foos.insert(0, Foo(a=7))
+    bar.foos.insert(2, dict(a=8))
+    with pytest.raises(ts.FieldTypeMismatch):
+        bar.foos.insert(1, 9)
+    assert bar.foos == [Foo(a=7), Foo(a=4), Foo(a=8), Foo(a=5)]
+
+    bar.nums.insert(0, 4)
+    assert bar.nums == [4, 3]
+
+    # Assignment
+    bar.foos = [Foo(a=10), dict(a=11)]
+    with pytest.raises(ts.FieldTypeMismatch):
+        bar.foos = [12]
+    assert bar.foos == [Foo(a=10), Foo(a=11)]
+
+    bar.nums = [5]
+    assert bar.nums == [5]
+
+    # __iadd__()
+    bar.foos += [Foo(a=13), dict(a=14)]
+    with pytest.raises(ts.FieldTypeMismatch):
+        bar.foos += [15]
+    assert bar.foos == [Foo(a=10), Foo(a=11), Foo(a=13), Foo(a=14)]
+
+    bar.nums += [6]
+    assert bar.nums == [5, 6]
+
+    # extend()
+    bar.foos.extend(iter([Foo(a=16), dict(a=17)]))
+    with pytest.raises(ts.FieldTypeMismatch):
+        bar.foos.extend(range(18))
+    assert bar.foos == [Foo(a=10), Foo(a=11), Foo(a=13), Foo(a=14), Foo(a=16), Foo(a=17)]
+
+    bar.nums.extend(iter([7]))
+    assert bar.nums == [5, 6, 7]
+
+    # Make sure that bar.foos and bar.nums are still a ListCollection
+    assert bar.foos.M.a.C == [10, 11, 13, 14, 16, 17]
+    assert bar.nums.M.call(lambda x: x * 10).C == [50, 60, 70]
+
+
+@pytest.mark.parametrize("use_full_syntax", [True, False])
+def test_typed_struct_dict_fields(use_full_syntax):
+    class Foo(ts.TypedStruct):
+        a = int
+
+    if use_full_syntax:
+        class Bar(ts.TypedStruct):
+            foos = ts.Field({int: Foo})
+            nums = ts.Field({int: int})
+    else:
+        class Bar(ts.TypedStruct):
+            foos = {int: Foo}
+            nums = {int: int}
+
+    bar = Bar()
+
+    # __setitem__()
+
+    bar.foos[1] = Foo(a=2)
+    bar.foos[3] = dict(a=4)
+    with pytest.raises(ts.FieldTypeMismatch):
+        bar.foos[6] = 7
+    with pytest.raises(ts.FieldKeyTypeMismatch):
+        bar.foos['8'] = Foo(a=9)
+    assert bar.foos == {1: Foo(a=2), 3: Foo(a=4)}
+
+    bar.nums[1] = 2
+    with pytest.raises(ts.FieldTypeMismatch):
+        bar.nums[3] = '4'
+    with pytest.raises(ts.FieldKeyTypeMismatch):
+        bar.nums['5'] = 6
+    assert bar.nums == {1: 2}
+
+    # Assignment
+
+    bar.foos = {5: dict(a=6), 7: Foo(a=8)}
+    with pytest.raises(ts.FieldTypeMismatch):
+        bar.foos = {9: 10}
+    with pytest.raises(ts.FieldKeyTypeMismatch):
+        bar.foos = {'11': Foo(a=12)}
+    assert bar.foos == {5: Foo(a=6), 7: Foo(a=8)}
+
+    bar.nums = {7: 8}
+    with pytest.raises(ts.FieldTypeMismatch):
+        bar.nums = {9: '10'}
+    with pytest.raises(ts.FieldKeyTypeMismatch):
+        bar.nums = {'11': 12}
+    assert bar.nums == {7: 8}
+
+    # setdefault()
+
+    assert bar.foos.setdefault(5, Foo(a=13)).a == 6  # from the assignments tests
+    assert bar.foos.setdefault(14, Foo(a=15)).a == 15
+    assert bar.foos.setdefault(16, dict(a=17)).a == 17
+    with pytest.raises(ts.FieldTypeMismatch):
+        bar.foos.setdefault(18, 19)
+    with pytest.raises(ts.FieldKeyTypeMismatch):
+        bar.foos.setdefault('20', Foo(a=21))
+    assert bar.foos == {5: Foo(a=6), 7: Foo(a=8), 14: Foo(a=15), 16: Foo(a=17)}
+
+    assert bar.nums.setdefault(7, 13) == 8  # NOTE: from the assignments tests
+    assert bar.nums.setdefault(14, 15) == 15
+    with pytest.raises(ts.FieldTypeMismatch):
+        bar.nums.setdefault(16, '17')
+    with pytest.raises(ts.FieldKeyTypeMismatch):
+        bar.nums.setdefault('18', 19)
+    assert bar.nums == {7: 8, 14: 15}
+
+    bar.foos.clear()  # it got too big
+
+    # update()
+
+    # NOTE: I can't test the .update(bla=...) syntax, because I only accept
+    # ints here.
+
+    bar.foos.update({22: Foo(a=23), 24: dict(a=25)})
+    with pytest.raises(ts.FieldTypeMismatch):
+        bar.foos.update({26: 27})
+    with pytest.raises(ts.FieldKeyTypeMismatch):
+        bar.foos.update({'28': Foo(a=29)})
+    assert bar.foos == {22: Foo(a=23), 24: Foo(a=25)}
+
+    bar.nums.update({20: 21})
+    with pytest.raises(ts.FieldTypeMismatch):
+        bar.nums.update({22: '23'})
+    with pytest.raises(ts.FieldKeyTypeMismatch):
+        bar.nums.update({'24': 25})
+    assert bar.nums == {7: 8, 14: 15, 20: 21}
+
+
+@pytest.mark.parametrize("use_full_syntax", [True, False])
+def test_typed_struct_bunch_fields(use_full_syntax):
+    if use_full_syntax:
+        class Bar(ts.TypedStruct):
+            nums = ts.Field({str: int})
+    else:
+        class Bar(ts.TypedStruct):
+            nums = {str: int}
+
+    bar = Bar()
+
+    # NOTE: TypedBunch shares most things with TypedDict, so I'm only doing a quick sanity test
+
+    bar.nums.a = 1
+    bar.nums['b'] = 2
+    bar.nums.update(c=3)
+    with pytest.raises(ts.FieldTypeMismatch):
+        bar.nums.d = '4'
+    with pytest.raises(ts.FieldKeyTypeMismatch):
+        bar.nums[5] = 6
+
+    assert bar.nums == Bunch(a=1, b=2, c=3)
+
+
+def test_typed_struct_field_defaults():
+    class Foo(ts.TypedStruct):
+        x = int
+
+    class Bar(ts.TypedStruct):
+        a = ts.Field(int, default=1)
+        b = ts.Field([int], default=[2, 3])
+        c = ts.Field(Foo, default=Foo(x=4))
+        d = ts.Field(Foo, default=dict(x=5))
+        e = ts.Field([Foo], default=[Foo(x=6), dict(x=7)])
+        f = ts.Field({str: Foo}, default=dict(g=Foo(x=8)))
+
+    bar1 = Bar()
+    bar2 = Bar()
+
+    assert bar1.a == bar2.a == 1
+
+    assert bar1.b == bar2.b == [2, 3]
+    assert bar1.b is not bar2.b
+
+    assert bar1.c == bar2.c == Foo(x=4)
+    assert bar1.c is not bar2.c
+
+    assert bar1.d == bar2.d == Foo(x=5)
+    assert bar1.d is not bar2.d
+
+    assert bar1.e == bar2.e == [Foo(x=6), Foo(x=7)]
+    assert bar1.e is not bar2.e
+    assert bar1.e[0] is not bar2.e[0]
+    assert bar1.e[1] is not bar2.e[1]
+
+    assert bar1.f == bar2.f == Bunch(g=Foo(x=8))
+    assert bar1.f is not bar2.f
+    assert bar1.f.g is not bar2.f.g
+
+
+def test_typed_struct_metadata():
+    class Foo(ts.TypedStruct):
+        a = ts.Field(int, meta=dict(format='%d'))
+        b = ts.Field(int, meta=dict(format='%03d'))
+
+    class Bar(ts.TypedStruct):
+        c = ts.Field(str, meta=dict(format='%s'))
+        d = ts.Field(str, meta=dict(format='"%s"'))
+
+    def format_object(obj):
+        def gen():
+            for k, v in obj.items():
+                field = getattr(type(obj), k)
+                formatted = field.meta.format % (v,)
+                yield '%s=%s' % (k, formatted)
+        return '%s[%s]' % (type(obj).__name__, ', '.join(gen()))
+
+    assert format_object(Foo(a=1, b=2)) == 'Foo[a=1, b=002]'
+    assert format_object(Bar(c='3', d='4')) == 'Bar[c=3, d="4"]'
+
+
+def test_typed_struct_convert():
+    class Foo(ts.TypedStruct):
+        a = ts.Field(int)
+        a.add_conversion(str, int)
+        a.add_conversion(float, int)
+
+    assert Foo(a=1).a == 1
+    assert Foo(a='2').a == 2
+    assert Foo(a=3.4).a == 3
+    with pytest.raises(ts.FieldTypeMismatch):
+        # Don't know how to convert complex
+        Foo(a=5 + 6j).a
+
+
+@pytest.mark.parametrize("use_helper_methods", [True, False])
+def test_typed_struct_preprocess(use_helper_methods):
+    class Error1(Exception):
+        pass
+
+    class Error2(Exception):
+        pass
+
+    if use_helper_methods:
+        class Foo(ts.TypedStruct):
+            a = ts.Field(int)
+
+            a.add_validation(lambda n: n % 2 == 0, Error1, 'not an even number')
+            a.add_validation(range(10, 31).__contains__, Error2, 'out of range([10, 30])')
+
+            a.add_conversion(str, int)
+            a.add_conversion(float, int)
+    else:
+        def preprocess(obj):
+            if isinstance(obj, str) or isinstance(obj, float):
+                obj = int(obj)
+
+            if isinstance(obj, int):
+                if obj % 2 == 1:
+                    raise Error1('not an even number')
+                if obj not in range(10, 31):
+                    raise Error2('out of range([10, 30])')
+
+            return obj
+
+        class Foo(ts.TypedStruct):
+            a = ts.Field(int, preprocess=preprocess)
+
+    assert Foo(a=12).a == 12
+    assert Foo(a='12').a == 12
+    assert Foo(a=12.0).a == 12
+
+    with pytest.raises(ts.FieldTypeMismatch):
+        Foo(a=[])
+
+    # Raising errors on validations:
+
+    with pytest.raises(Error1) as exc:
+        Foo(a=13)
+    assert exc.value.args[0] == 'not an even number'
+
+    with pytest.raises(Error2) as exc:
+        Foo(a=32)
+    assert exc.value.args[0] == 'out of range([10, 30])'
+
+    # Raising errors on validations even after conversions:
+
+    with pytest.raises(Error1):
+        Foo(a=13.0)
+
+    with pytest.raises(Error2):
+        Foo(a='32')


### PR DESCRIPTION
* Simple definition syntax - without repeating field names.
* Short syntax for simple fields - workds with IDE completion.
* Full `ts.Field(...)` syntax to define default value, validators etc.
* `meta` field that can be used to provide metadata for reflection.
* Support for typechecked `list`, `dict` and `Bunch` fields.

Future plans(will need more design):

* Hooks/signals for doing things when users change the fields.
* Bubble up? Parent `TypedStruct`'s hook get activated when
  fields of nested `TypedStruct`s are changed?