### PR TITLE
Fix a deadlock-causing race-condition in `TagAlongThread`:

### DIFF
--- a/easypy/concurrency.py
+++ b/easypy/concurrency.py
@@ -1193,8 +1193,14 @@ class TagAlongThread(object):
 
         self._iteration_trigger.set()  # Signal that we want an iteration
 
-        self._iterating.wait()  # Wait until an iteration starts
-        self._not_iterating.wait()  # Wait until it finishes
+        while not self._iterating.wait(1):  # Wait until an iteration starts
+            # It is possible that we missed the loop and _iterating was already
+            # cleared. If this is the case, _not_iterating will not be set -
+            # and we can use it as a signal to stop waiting for iteration.
+            if self._not_iterating.is_set():
+                break
+        else:
+            self._not_iterating.wait()  # Wait until it finishes
 
         # To avoid races, copy last exception and result to local variables
         last_exception, last_result = self._last_exception, self._last_result


### PR DESCRIPTION
The race - "_T_" is the `TagAlongThread`, "_C_" is the caller thread:
- _T_ waits on `_iteration_trigger`.
- _C_ sets `_iteration_trigger`.
- _T_ sets `_iterating`.
- _T_ performs the loop too fast - before _C_ has a chance to do anything.
- _T_ clears `_iterating`.
- _C_ waits on `_iterating`.
- _T_ starts over again - and waits on `_iteration_trigger`.

_C_ is waiting for _T_ to set `_iterating` - but _T_ has already set it
and cleared it, and won't set it again until someone else sets
`_iteration_trigger`. This may never happen because _C_ is stuck and the
program can't progress...

The solution that every second _C_ will look at `_not_iterating` - an
`Event` that we already have for a different purpose and gets set after
the iteration is done.

Now, in theory, a deadlock is still possible - but it would require
exact timing that must repeat every second, so we should be safe.