### PR TITLE
Callable `wait` message

### DIFF
--- a/easypy/timing.py
+++ b/easypy/timing.py
@@ -285,6 +285,8 @@ def iter_wait(timeout, pred=None, sleep=0.5, message=None,
             if expired:
                 duration = l_timer.stop()
                 if throw:
+                    if callable(message):
+                        message = message()
                     raise TimeoutException(message, duration=duration)
                 yield None
                 return

--- a/tests/test_timing.py
+++ b/tests/test_timing.py
@@ -3,6 +3,7 @@ import pytest
 
 from easypy.timing import iter_wait, wait, repeat, iter_wait_progress, Timer, TimeoutException
 from easypy.bunch import Bunch
+from easypy.concurrency import concurrent
 
 
 # Temporary tests for iter_wait() warnings
@@ -96,3 +97,16 @@ def test_wait_long_predicate():
             wait(3)
 
     wait(2, pred)
+
+
+def test_wait_with_callable_message():
+    val = ['FOO']
+
+    with pytest.raises(TimeoutException) as e:
+        def pred():
+            val[0] = 'BAR'
+            return False
+        wait(pred=pred, timeout=1, message=lambda: 'val is %s' % val[0])
+
+    assert val[0] == 'BAR'
+    assert e.value.message == 'val is BAR'


### PR DESCRIPTION
Currently the message we display when `wait` times out is generated
**before** the waiting. This means we can't write in it things related
to the state **after** the waiting.

This commit supports a lambda message, that will be invoked after the
timeout and thus can have up-to-date information in it.