### PR TITLE
Properly display timezone in `short_utc_fmt`

### DIFF
--- a/easypy/timezone.py
+++ b/easypy/timezone.py
@@ -98,6 +98,10 @@ def parse_isoformat(source):
         return timestamp
 
 
-short_utc_fmt = lambda dt: "%s,%02dZ" % (dt.strftime("%T"), dt.microsecond//10000)
+def short_utc_fmt(dt):
+    tzname = dt.tzname() or ''
+    if tzname.startswith('UTC'):
+        tzname = tzname[3:] or 'Z'
+    return "%s,%02d%s" % (dt.strftime("%T"), dt.microsecond // 10000, tzname)
 
 utc_ts = lambda: int(TimeZone.utc.now().timestamp())

--- a/tests/test_timezone.py
+++ b/tests/test_timezone.py
@@ -1,5 +1,5 @@
-import datetime
-from easypy.timezone import TimeZone, parse_isoformat
+from datetime import datetime, timedelta
+from easypy.timezone import TimeZone, parse_isoformat, short_utc_fmt
 
 
 def test_conversions():
@@ -10,6 +10,25 @@ def test_conversions():
             '2001-02-03T04:05:06.000007+08:00',
             ]:
         assert parse_isoformat(timestamp).isoformat() == timestamp
-    assert parse_isoformat('2001-02-03T04:05:06.000007Z') == datetime.datetime(2001, 2, 3, 4, 5, 6, 7, TimeZone.utc)
+    assert parse_isoformat('2001-02-03T04:05:06.000007Z') == datetime(2001, 2, 3, 4, 5, 6, 7, TimeZone.utc)
     assert parse_isoformat('2001-02-03T04:05:06+02:00').astimezone(TimeZone.utc) == parse_isoformat('2001-02-03T00:05:06-02:00').astimezone(TimeZone.utc)
     assert parse_isoformat('2001-02-03T04:05:06+02:00').utcoffset().seconds == 2 * 3600
+
+
+def test_short_utc_fmt():
+    dt = datetime(2001, 2, 3, 4, 5, 6, 70000, TimeZone.utc)
+    assert short_utc_fmt(dt) == '04:05:06,07Z'
+
+    # No timezone
+    assert short_utc_fmt(dt.replace(tzinfo=None)) == '04:05:06,07'
+
+    # Nameless timezones - use the offset to display
+    nameless_timezone = TimeZone(offset=timedelta(hours=6))
+    assert short_utc_fmt(dt.astimezone(nameless_timezone)) == '10:05:06,07+06:00'
+
+    nameless_timezone_2 = TimeZone(offset=timedelta(hours=-3))
+    assert short_utc_fmt(dt.astimezone(nameless_timezone_2)) == '01:05:06,07-03:00'
+
+    # Weka Time - a fake timezone that doesn't have DST
+    wkt = TimeZone(offset=timedelta(hours=5), tzname='WKT')
+    assert short_utc_fmt(dt.astimezone(wkt)) == '09:05:06,07WKT'


### PR DESCRIPTION
- UTC timezone will be displayed as 'Z'.
- Named timezone will be displayed with their name(e.g. 'IST')
- Nameless timezones will be displayed with their offset(e.g. '+02:00')