### PR TITLE
Automatically convert fields in `TypedStruct` definition to `Field`

### DIFF
--- a/tests/test_typed_struct.py
+++ b/tests/test_typed_struct.py
@@ -502,3 +502,13 @@ def test_typed_struct_collection_type_verification():
         Foo(c='13')
     with pytest.raises(ts.FieldCollectionTypeMismatch):
         Foo(c=['14'])
+
+
+def test_typed_struct_auto_field_wrapping_dsl():
+    class Foo(ts.TypedStruct):
+        a = int
+        a.default = 1
+        b = float
+        b.convertible_from(str)
+
+    assert Foo(b='2.3').to_dict() == dict(a=1, b=2.3)


### PR DESCRIPTION
Previously, if you wanted to - for example - add a conversion to a
field, you'd have to do this:

```python
class Foo(ts.TypedStruct):
    a = ts.Field(int)
    a.convertible_from(str)
```

Or this:

```python
class Foo(ts.TypedStruct):
    a = int
Foo.a.convertible_from(str)
```

With this commit, you can do this:

```python
class Foo(ts.TypedStruct):
    a = int
    a.convertible_from(str)
```

This is the first step of a better `TypedStruct` API that I'm planning. For the next step, I want to support things like this:

```python
class Foo(TypedStruct):
    with convertible_from(int, float, str):
        a = int
        b = float
        c = [int]
```

Note that currently we do things like this:

```python
def numeric_field(field_type, **kwargs):
    field = ts.Field(field_type, **kwargs)
    field.add_conversion(int, float, str)
    return field

class Foo(ts.TypedStruct):
    a = numeric_field(int)
    b = numeric_field(float)
    c = numeric_field([int])
```
