### PR TITLE
`default` DSL and `@singleton` for nicer `TypedStruct` instantiation syntax

### DIFF
--- a/easypy/decorations.py
+++ b/easypy/decorations.py
@@ -234,3 +234,18 @@ def lazy_decorator(decorator_factory):
     def wrapper(func):
         return LazyDecoratorDescriptor(decorator_factory, func)
     return wrapper
+
+
+def singleton(cls):
+    """
+    Convert the class into an instance of it::
+
+    >>> @singleton
+    >>> class foo:
+    >>>     def __init__(self):
+    >>>         self.x = 10
+    >>> foo.x
+    10
+    """
+
+    return cls()

--- a/tests/test_decorations.py
+++ b/tests/test_decorations.py
@@ -2,7 +2,7 @@ import pytest
 
 from functools import wraps
 
-from easypy.decorations import deprecated_arguments, kwargs_resilient, lazy_decorator
+from easypy.decorations import deprecated_arguments, kwargs_resilient, lazy_decorator, singleton
 
 
 def test_deprecated_arguments():
@@ -111,3 +111,17 @@ def test_lazy_decorator_attribute():
     foo.num = 20
     assert foo.foo() == 21
     assert foo.foo.__name__ == 'foo + 20'
+
+
+def test_singleton():
+    @singleton
+    class foo:
+        a = 1
+
+        def __init__(self):
+            self.b = 2
+
+    assert foo.a == 1
+    assert foo.b == 2
+    assert type(foo).a == 1
+    assert not hasattr(type(foo), 'b')

--- a/tests/test_typed_struct.py
+++ b/tests/test_typed_struct.py
@@ -1,6 +1,7 @@
 import pytest
 
 from easypy.bunch import Bunch
+from easypy.decorations import singleton
 
 import easypy.typed_struct as ts
 
@@ -512,3 +513,51 @@ def test_typed_struct_auto_field_wrapping_dsl():
         b.convertible_from(str)
 
     assert Foo(b='2.3').to_dict() == dict(a=1, b=2.3)
+
+
+def test_typed_struct_singleton_subclasses_style():
+    class Foo(ts.TypedStruct):
+        a = int
+        a.convertible_from(str)
+
+    @singleton
+    class foo(Foo):
+        a = '5'
+
+    assert foo.a == 5
+
+    class bar(Foo):
+        a = '5'
+
+    assert isinstance(bar.a, ts.Field)  # bar is a type, not an instance
+
+
+def test_typed_struct_order_of_multiple_inheritance():
+    class Foo(ts.TypedStruct):
+        a = int
+        a = 0
+
+    class Foo1(Foo):
+        a = 1
+
+    class Foo2(Foo):
+        a = 2
+
+    @singleton
+    class foo(Foo1, Foo2):
+        pass
+
+    class Bar:
+        a = 0
+
+    class Bar1(Bar):
+        a = 1
+
+    class Bar2(Bar):
+        a = 2
+
+    @singleton
+    class bar(Bar1, Bar2):
+        pass
+
+    assert foo.a == bar.a, 'Order of multiple inheritance should be the same for TypedStruct and regular classes'


### PR DESCRIPTION
As I suggested in https://github.com/weka-io/black-magic/issues/1#issuecomment-392991732 - this allows the nice syntax you can see in `test_typed_struct_singleton_subclasses_style`.