### PR TITLE
concurrency: bug fix for MultiException of multi-inherited types

### DIFF
--- a/easypy/concurrency.py
+++ b/easypy/concurrency.py
@@ -184,7 +184,7 @@ class MultiExceptionMeta(type):
             with cls._SUBTYPES_LOCK:
                 if exception_type in cls._SUBTYPES:
                     return cls._SUBTYPES[exception_type]
-                bases = tuple(cls[base] for base in exception_type.__bases__ if base)
+                bases = tuple(cls[base] for base in exception_type.__bases__ if base and issubclass(base, BaseException))
                 subtype = type("MultiException[%s]" % exception_type.__qualname__, bases, {})
                 cls._SUBTYPES[exception_type] = subtype
                 return subtype

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -329,6 +329,33 @@ def test_multiexception_api():
     assert sucsessful.exception() is None
 
 
+def test_multiexception_types():
+
+    class OK(Exception):
+        pass
+
+    class BAD(object):
+        pass
+
+    class OKBAD(OK, BAD):
+        pass
+
+    with pytest.raises(AssertionError):
+        MultiException[BAD]
+
+    def raise_it(typ):
+        raise typ()
+
+    with pytest.raises(MultiException[OK]):
+        MultiObject([OK]).call(raise_it)
+
+    with pytest.raises(MultiException[OKBAD]):
+        MultiObject([OKBAD]).call(raise_it)
+
+    with pytest.raises(MultiException[OK]):
+        MultiObject([OKBAD]).call(raise_it)
+
+
 def test_logged_condition():
     cond = LoggedCondition('test', log_interval=.1)
 


### PR DESCRIPTION
This is to allow creation of a MultiException sub-type out of a type that
mixes a BaseException subclass with non-BaseException classes