### PR TITLE
Close #80: Add `EasyMeta` (for now with only one hook)

### DIFF
--- a/easypy/meta.py
+++ b/easypy/meta.py
@@ -1,0 +1,104 @@
+from abc import ABCMeta
+from functools import wraps
+from collections import OrderedDict
+
+from .decorations import kwargs_resilient
+
+
+class EasyMeta(ABCMeta):
+    """
+    Base class for various meta-magic mixins.
+
+    Use the hooks in :class:`EasyMetaHooks`, decorated with `@EasyMeta.Hook`,
+    to add functionality. Multiple hooks with the same name can be defined,
+    and they will all be invoked sequentially.
+    """
+
+    @classmethod
+    def __prepare__(metacls, name, bases, **kwds):
+        dsl = EasyMetaDslDict()
+        return dsl
+
+    class Hook(object):
+        def __init__(self, dlg):
+            self.dlg = dlg
+
+    def __init__(cls, name, bases, dct, **kwargs):
+        super().__init__(name, bases, dct)
+
+    def __new__(mcs, name, bases, dct, **kwargs):
+        hooks = EasyMetaHooks(class_kwargs=kwargs)
+
+        for base in bases:
+            if isinstance(base, EasyMeta):
+                hooks.extend(base._em_hooks)
+
+        new_type = super().__new__(mcs, name, bases, dct)
+
+        new_type._em_hooks = hooks
+
+        hooks.after_subclass_init(new_type)
+
+        hooks.extend(dct.hooks)
+
+        return new_type
+
+
+class EasyMetaHooks:
+    """
+    Hooks for ``EasyMeta``
+    """
+
+    HOOK_NAMES = []
+
+    def hook(dlg, HOOK_NAMES=HOOK_NAMES):
+        HOOK_NAMES.append(dlg.__name__)
+
+        @wraps(dlg)
+        def hook(self, *args, **kwargs):
+            kwargs_resilience = kwargs_resilient(negligible=self.class_kwargs.keys())
+            kwargs.update((k, v) for k, v in self.class_kwargs.items() if k not in kwargs)
+
+            for hook in self.hooks[dlg.__name__]:
+                kwargs_resilience(hook)(*args, **kwargs)
+
+        return hook
+
+    def __init__(self, class_kwargs={}):
+        self.hooks = {name: [] for name in self.HOOK_NAMES}
+        self.class_kwargs = class_kwargs
+
+    def add(self, hook):
+        self.hooks[hook.__name__].append(hook)
+
+    def extend(self, other):
+        for k, v in other.hooks.items():
+            self.hooks[k].extend(v)
+
+    @hook
+    def after_subclass_init(self, cls):
+        """
+        Invoked after a subclass is being initialized
+
+        >>> class PrintTheName(metaclass=EasyMeta):
+        >>>     @EasyMeta.Hook
+        >>>     def after_subclass_init(cls):
+        >>>         print('Declared', cls.__name__)
+        >>>
+        >>>
+        >>> class Foo(PrintTheName):
+        >>>     pass
+        Declared Foo
+        """
+
+
+class EasyMetaDslDict(OrderedDict):
+    def __init__(self):
+        super().__init__()
+        self.hooks = EasyMetaHooks()
+
+    def __setitem__(self, name, value):
+        if isinstance(value, EasyMeta.Hook):
+            self.hooks.add(value.dlg)
+        else:
+            return super().__setitem__(name, value)

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -1,0 +1,25 @@
+from easypy.meta import EasyMeta
+
+
+def test_easy_meta_after_cls_init():
+    class Foo(metaclass=EasyMeta):
+        @EasyMeta.Hook
+        def after_subclass_init(cls):
+            cls.foo_init = cls.__name__
+
+    class Bar(metaclass=EasyMeta):
+        @EasyMeta.Hook
+        def after_subclass_init(cls):
+            cls.bar_init = cls.__name__
+
+    class Baz(Foo, Bar):
+        @EasyMeta.Hook
+        def after_subclass_init(cls):
+            cls.baz_init = cls.__name__
+
+    assert not hasattr(Foo, 'foo_init'), 'after_subclass_init declared in Foo invoked on Foo'
+    assert not hasattr(Bar, 'bar_init'), 'after_subclass_init declared in Bar invoked on Bar'
+
+    assert Baz.foo_init == 'Baz'
+    assert Baz.bar_init == 'Baz'
+    assert not hasattr(Baz, 'baz_init'), 'after_subclass_init declared in Baz invoked on Baz'


### PR DESCRIPTION
Also add first mixin (constructor) that uses `EasyMeta`: `auto_registrar`.

This is a proof of concept for combinable meta mixins - in the future we will add more hooks that'll allow more mixins.

The syntax is a bit different than what I wrote in #80. I'm decorating the hooks with `EasyMeta.Hook`, and making the DSL (the dictionary used in the class declaration) "swallow" them - so that they won't appear in the actual class. This also means we don't need to fear several mixins using the same hook overwriting each other's work. But this also means I'll have to do something about hooks we can only have one of (e.g. hooks that replace instance creation). Still - better than having these hooks decided arbitrarily by the order of baseclass resolution...