### PR TITLE
Add `repr` and `hash` to typed struct fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `wait` and `iter_wait` support `log_interval` and `log_level` for printing
   the thrown `PredicateNotSatisfied` to the log.
 - `takesome`: a new generator that partially yields a sequence
+- `repr` and `hash` to typed struct fields.
 
 ### Fixed
 - `ExponentialBackoff`: return the value **before** the incrementation.

--- a/easypy/humanize.py
+++ b/easypy/humanize.py
@@ -594,20 +594,24 @@ def format_size(num, suffix='B'):
     return "%.1f%s%s" % (num, 'Yi', suffix)
 
 
-def ipython_mapping_repr(mapping, p, cycle):
-    # used by IPython. add to any mapping class as '_repr_pretty_'
+def ipython_fields_repr(name, field_items, p, cycle):
     from easypy.colors import DARK_CYAN
     if cycle:
-        p.text('%s(...)' % mapping.__class__.__name__)
+        p.text('%s(...)' % (name,))
         return
-    prefix = '%s(' % mapping.__class__.__name__
+    prefix = '%s(' % (name,)
     with p.group(len(prefix), prefix, ')'):
-        for idx, (k, v) in enumerate(sorted(mapping.items())):
+        for idx, (k, v) in enumerate(field_items):
             if idx:
                 p.text(',')
                 p.breakable()
             with p.group(len(k)+1, DARK_CYAN(k) + "="):
-                p.pretty(mapping[k])
+                p.pretty(v)
+
+
+def ipython_mapping_repr(mapping, p, cycle):
+    """Used by IPython. add to any mapping class as '_repr_pretty_'"""
+    ipython_fields_repr(mapping.__class__.__name__, sorted(mapping.items()), p, cycle)
 
 
 BAR_SEQUENCE = ' ▏▎▍▌▋▊▉██'
@@ -690,3 +694,11 @@ def percentages_comparison(actual, expected, key_caption='Item', color_bounds={'
     for item in sorted(generate(), key=lambda a: a.abs_diff, reverse=True):
         table.add_row(**item)
     return table
+
+
+class _ReprAsString:
+    def __init__(self, value):
+        self.value = value
+
+    def __repr__(self):
+        return str(self.value)

--- a/tests/test_typed_struct.py
+++ b/tests/test_typed_struct.py
@@ -530,3 +530,40 @@ def test_typed_struct_inheritance():
 
     assert Foo().to_dict() == dict(a=1, b=2)
     assert Bar().to_dict() == dict(a=3, b=2, c=4)
+
+
+def test_typed_struct_repr():
+    class Foo(ts.TypedStruct):
+        a = int
+        b = float
+        b.repr = False
+        c = str
+        c.repr = '`{}`'.format
+
+    assert repr(Foo(a=1, b=2.0, c='3')) == 'Foo(a=1, c=`3`)'
+
+
+def test_typed_struct_hash():
+    class Foo(ts.TypedStruct):
+        a = int
+        b = int
+        b.hash = False
+        c = int
+        c.hash = lambda n: n % 2
+
+
+    assert hash(Foo(a=1, b=2, c=3)) == hash(Foo(a=1, b=2, c=3))
+    assert hash(Foo(a=1, b=2, c=3)) != hash(Foo(a=2, b=2, c=3))
+    assert hash(Foo(a=1, b=2, c=3)) == hash(Foo(a=1, b=1, c=3)), 'b should not be part of the hash'
+    assert hash(Foo(a=1, b=2, c=3)) == hash(Foo(a=1, b=2, c=1)), 'Only the parity of c should be in the hash'
+    assert hash(Foo(a=1, b=2, c=3)) != hash(Foo(a=1, b=2, c=2)), 'c with different parity should generate different hash'
+
+    class Bar(ts.TypedStruct):
+        a = int
+        b = int
+        b.hash = False
+        c = int
+        c.hash = lambda n: n % 2
+
+    assert hash(Foo(a=1, b=2, c=3)) != hash(Bar(a=1, b=2, c=3)), \
+        'different classes with same fields should have different hahses'


### PR DESCRIPTION
* `repr` can configure how the field in represented in textual
  representation of the typed struct.
* `hash` can configure how the field is considered when hashing the
  typed struct.