### PR TITLE
Fix `Signal.unregister` for context manager signals

### DIFF
--- a/easypy/signals.py
+++ b/easypy/signals.py
@@ -10,6 +10,7 @@ from contextlib import contextmanager, ExitStack
 from easypy.concurrency import Futures, MultiObject
 from easypy.decorations import parametrizeable_decorator, kwargs_resilient
 from easypy.exceptions import TException
+from easypy.contexts import is_contextmanager
 
 PRIORITIES = Enum("PRIORITIES", "FIRST NONE LAST")
 _logger = logging.getLogger(__name__)
@@ -37,7 +38,10 @@ def get_original_func(func):
     while True:
         if isinstance(func, functools.partial):
             func = func.func
-        elif hasattr(func, "__wrapped__"):
+        elif hasattr(func, "__wrapped__") and not (
+            is_contextmanager(func) and not is_contextmanager(func.__wrapped__)
+            # This means func is the context manager itself (which wraps a non-context-manager function)
+        ):
             func = func.__wrapped__
         else:
             return func

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -152,3 +152,32 @@ def test_async():
     on_test()
 
     on_test.async = False
+
+
+def test_ctx():
+    from contextlib import contextmanager
+    from easypy.signals import on_ctx_test
+
+    result = []
+
+    class Foo:
+        @contextmanager
+        def on_ctx_test(self, before, after):
+            result.append(before)
+            yield
+            result.append(after)
+
+    foo = Foo()
+
+    register_object(foo)
+
+    assert result == []
+    with on_ctx_test(before=1, after=2):
+        assert result == [1]
+    assert result == [1, 2]
+
+    unregister_object(foo)
+
+    with on_ctx_test(before=3, after=4):
+        assert result == [1, 2]
+    assert result == [1, 2]


### PR DESCRIPTION
We may not be able to solve the big leak, but this is definitely a bug!