### PR TITLE
Add `exception_to_boolean`

### DIFF
--- a/tests/test_resilience.py
+++ b/tests/test_resilience.py
@@ -1,0 +1,86 @@
+import pytest
+
+from easypy.resilience import exception_to_boolean
+
+
+def test_exception_to_boolean():
+    @exception_to_boolean
+    def foo(exc):
+        if isinstance(exc, type) and issubclass(exc, Exception):
+            raise exc
+
+    @exception_to_boolean
+    def bar(exc):
+        foo.func(exc)
+
+    assert foo(None) == True
+    assert foo(Exception) == False
+    assert bar(None) == True
+    assert bar(Exception) == False
+
+    foo.func(None)
+    bar.func(None)
+    with pytest.raises(Exception):
+        foo.func(Exception)
+    with pytest.raises(Exception):
+        bar.func(Exception)
+
+    class FooException(Exception): pass
+
+    with pytest.raises(FooException):
+        foo.func(FooException)
+    with pytest.raises(FooException):
+        bar.func(FooException)
+
+
+def test_exception_to_boolean_type_limitation():
+    class FooException(Exception): pass
+    class BarException(FooException): pass
+
+    @exception_to_boolean(acceptable=FooException, unacceptable=BarException)
+    def foo(exc):
+        raise exc
+
+    with pytest.raises(Exception):
+        foo(Exception)
+    assert foo(FooException) == False
+    with pytest.raises(BarException):
+        foo(BarException)
+
+
+def test_exception_to_boolean_for_methods():
+    class MyException(Exception): pass
+
+    class Foo:
+        @exception_to_boolean
+        def bar(self):
+            raise MyException
+
+        @exception_to_boolean
+        @classmethod
+        def baz(cls):
+            raise MyException
+
+        @exception_to_boolean
+        @staticmethod
+        def qux():
+            raise MyException
+
+    assert Foo().bar() == False
+    assert Foo().baz() == False
+    assert Foo().qux() == False
+
+    assert Foo.baz() == False
+    assert Foo.qux() == False
+
+    with pytest.raises(MyException):
+        Foo().bar.func()
+    with pytest.raises(MyException):
+        Foo().baz.func()
+    with pytest.raises(MyException):
+        Foo().qux.func()
+
+    with pytest.raises(MyException):
+        Foo.baz.func()
+    with pytest.raises(MyException):
+        Foo.qux.func()


### PR DESCRIPTION
I'm not really sure about the name, and I'm also not sure if `resilience` is the right place for this.

The ultimate goal of this is to allow easy transition to `PredicateNotSatisfied`. We have many places in our code that check if something is alive, or if certain conditions are met, and other places that `wait` on these functions. Making the functions that check them raise a `PredicateNotSatisfied` with relevant information would help us debug these timeouts, but because these methods are used all over the place it is too risky to make them throw instead of returning `False`.

By decorating these functions with `@exception_to_boolean` we could provide that information while still allowing to use them as simple predicates. For example, we have `WekaNode.is_alive()`:
```python
    def is_alive(self):
        return self.machine.is_alive() and bool(self.get_proc_info().pid)
```

Which calls `WekaMachine.is_alive()`:
```python
    def is_alive(self, timeout=5):
        with resilience():
            for _ in self.cmd.echo.popen().iter_lines(line_timeout=5):
                return True
        return False
```

These could be written as:

```python
# The one in WekaMachine

    @exception_to_boolean(acceptable=PredicateNotSatisfied)
    def is_alive(self, timeout=5):
        with resilience():
            for _ in self.cmd.echo.popen().iter_lines(line_timeout=5):
                return True
        raise PredicateNotSatisfied('{machine} did not respone', machine=self)

# The one in WekaNode

    @exception_to_boolean(acceptable=PredicateNotSatisfied)
    def is_alive(self):
        self.machine.is_alive.func()
        proc_info = self.get_proc_info()
        if not proc_info.pid:
            raise PredicateNotSatisfied('Process of {node} is dead. Proc info = {proc_info}', node=self, proc_info=proc_info)
        return True
```

(maybe we'll want to make `func()` swallow the returned value of the underlying function and **always** return `True` if it didn't throw)

With this, we can easily call `is_alive()` nodes and hosts and get a boolean result, but when `wait`ing on them we could call `is_alive.func()` to get a more detailed exception in case of timeout.