### PR TITLE
Signals handlers keep methods as weak references

### DIFF
--- a/easypy/decorations.py
+++ b/easypy/decorations.py
@@ -1,11 +1,12 @@
 import inspect
 import sys
 from contextlib import contextmanager
-from functools import wraps, partial
+from functools import wraps, partial, update_wrapper
 from types import MethodType
 import warnings
 from threading import RLock
 from operator import attrgetter
+import weakref
 
 from easypy.collections import intersected_dict, ilistify
 
@@ -117,6 +118,25 @@ def singleton_contextmanager_method(func):
     return inner
 
 
+class WeakMethodDead(Exception):
+    pass
+
+
+class WeakMethodWrapper:
+    def __init__(self, weak_method):
+        if isinstance(weak_method, MethodType):
+            weak_method = weakref.WeakMethod(weak_method)
+        self.weak_method = weak_method
+        update_wrapper(self, weak_method(), updated=())
+        self.__wrapped__ = weak_method
+
+    def __call__(self, *args, **kwargs):
+        method = self.weak_method()
+        if method is None:
+            raise WeakMethodDead
+        return method(*args, **kwargs)
+
+
 @parametrizeable_decorator
 def kwargs_resilient(func, negligible=None):
     """
@@ -127,7 +147,11 @@ def kwargs_resilient(func, negligible=None):
                 - Other parameters will be passed normally, even if they don't appear in the signature.
                 - If a specified parameter is not in the signature, don't pass it even if there are **kwargs.
     """
-    spec = inspect.getfullargspec(inspect.unwrap(func))
+    if isinstance(func, weakref.WeakMethod):
+        spec = inspect.getfullargspec(inspect.unwrap(func()))
+        func = WeakMethodWrapper(func)
+    else:
+        spec = inspect.getfullargspec(inspect.unwrap(func))
     acceptable_args = set(spec.args or ())
     if isinstance(func, MethodType):
         acceptable_args -= {spec.args[0]}

--- a/easypy/lockstep.py
+++ b/easypy/lockstep.py
@@ -143,4 +143,8 @@ class lockstep(object):
             process.step_all()
 
     def __get__(self, instance, owner=None):
-        return lockstep(self.generator_func.__get__(instance, owner))
+        func = self.generator_func.__get__(instance, owner)
+        if func is self.generator_func:
+            return self
+        else:
+            return lockstep(func)

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -181,3 +181,48 @@ def test_ctx():
     with on_ctx_test(before=3, after=4):
         assert result == [1, 2]
     assert result == [1, 2]
+
+
+def test_siganl_weakref():
+    """
+    Test that signals handlers of methods are deleted when their objects get collected
+    """
+    import gc
+    from easypy.signals import on_test
+
+    class Foo:
+        def on_test(self, a, b):
+            a / b
+
+    foo = Foo()
+    register_object(foo)
+
+    with pytest.raises(ZeroDivisionError):
+        on_test(a=5, b=0, c='c')
+
+    del foo
+    gc.collect()
+
+    on_test(a=5, b=0, c='c')
+
+
+def test_siganl_weakref_complex_descriptors():
+    import gc
+    from easypy.signals import on_test
+    from easypy.lockstep import lockstep
+
+    class Foo:
+        @lockstep
+        def on_test(self, a, b):
+            a / b
+
+    foo = Foo()
+    register_object(foo)
+
+    with pytest.raises(ZeroDivisionError):
+        on_test(a=5, b=0, c='c')
+
+    del foo
+    gc.collect()
+
+    on_test(a=5, b=0, c='c')


### PR DESCRIPTION
This makes signal handlers use weak references to methods so that they won't be keeping the objects alive.

Questions:
1. Do we want an opt-out argument?
2. Do we want to, instead of making `Signal.register()` convert methods to `WeakMethod`, have the conversion be done in `register_object` so that directly registered methods won't be weakly referenced?
    * On the one hand, these are methods too and we don't want the globally scoped signal to keep their objects alive.
    * On the other hand, one would usually register these methods with the `registered` context manager, so unregistration will be done automatically and weakreffing could be potentially harmful.