### PR TITLE
Fix `resilient` between `timecache`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - `ExponentialBackoff`: return the value **before** the incrementation.
 - `concurrent`: capture `KeyboardInterrupt` exceptions like any other.
-- doctests in various functions and classes
+- doctests in various functions and classes.
 - `SynchronizedSingleton` on `contextmanager` deadlock when some (but not all)
   of the CMs throw.
+- `resilient` between `timecache`s bug.
 
 ### Changed
 - Reorganization:

--- a/easypy/caching.py
+++ b/easypy/caching.py
@@ -217,6 +217,7 @@ else:
 
 class _TimeCache(DecoratingDescriptor):
     def __init__(self, func, **kwargs):
+        update_wrapper(self, func)  # this needs to be first to avoid overriding attributes we set
         super().__init__(func=func, cached=True)
         self.func = func
         self.kwargs = kwargs
@@ -254,8 +255,6 @@ class _TimeCache(DecoratingDescriptor):
                 return _make_key(args, kwargs, typed=self.typed)
 
         self.make_key = make_key
-
-        update_wrapper(self, self.func)
 
     def __call__(self, *args, **kwargs):
         key = self.make_key(args, kwargs)


### PR DESCRIPTION
Prevent `_TimeCache.__init__` from overriding the attributes it sets
with attributes of the wrapped function.