### PR TITLE
Don't leak open db, as it is concurrent access which has undefined behavior

### DIFF
--- a/easypy/caching.py
+++ b/easypy/caching.py
@@ -65,21 +65,22 @@ class PersistentCache(object):
             return
 
         from .resilience import retrying
-        with self.lock:
-            try:
-                db = retrying(3, acceptable=GDBMException, sleep=5)(shelve.open)(self.path)
-            except Exception:
-                try:
-                    os.unlink(self.path)
-                except FileNotFoundError:
-                    pass
-                try:
-                    db = shelve.open(self.path)
-                except Exception:
-                    _logger.warning("Could not open PersistentCache: %s", self.path)
-                    db = {}
-
         with ExitStack() as stack:
+            with self.lock:
+                try:
+                    db = stack.enter_context(
+                        retrying(3, acceptable=GDBMException, sleep=5)(shelve.open)(self.path))
+                except Exception:
+                    try:
+                        os.unlink(self.path)
+                    except FileNotFoundError:
+                        pass
+                    try:
+                        db = stack.enter_context(shelve.open(self.path))
+                    except Exception:
+                        _logger.warning("Could not open PersistentCache: %s", self.path)
+                        db = {}
+
             timestamp = time.time()
             c_version, c_timestamp = db.get("_PersistentCacheSignature", [0, 0])
             if not ((c_version >= self.version) and (self.expiration is None or (c_timestamp + self.expiration) > timestamp)):
@@ -89,9 +90,6 @@ class PersistentCache(object):
             if lock:
                 stack.enter_context(self.lock)
             yield db
-
-        if type(db) is not dict:
-            db.close()
 
     def set(self, key, value):
         with self.db_opened(lock=True) as db:

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -1,6 +1,6 @@
 import pytest
 from easypy.collections import separate
-from easypy.collections import ListCollection, SimpleObjectCollection, partial_dict, UNIQUE, ObjectNotFound
+from easypy.collections import ListCollection, SimpleObjectCollection, partial_dict, UNIQUE, ObjectNotFound, TooManyObjectsFound
 from easypy.bunch import Bunch
 from collections import Counter
 
@@ -80,6 +80,12 @@ def test_collection_sample_too_much():
     len(L.select(name='a', id='2').sample(100)) == 100
     with pytest.raises(ObjectNotFound):
         L.select(name='a', id='2').sample(101)
+
+
+def test_collection_sample_too_many():
+    len(L.select(name='a', id='2').sample(100)) == 100
+    with pytest.raises(TooManyObjectsFound):
+        L.get(name='a', id='2')
 
 
 def test_collection_sample_unique0():


### PR DESCRIPTION
It may explain the double-prompting for the code in most uses, and it explains the loss of all writes when using the "dumb" dbm module