### PR TITLE
collections: workaround python bug importing 'test.support'

### DIFF
--- a/easypy/typed_struct.py
+++ b/easypy/typed_struct.py
@@ -2,8 +2,9 @@ from copy import deepcopy
 
 from .exceptions import TException
 from .tokens import AUTO, MANDATORY
-from .collections import ListCollection, PythonOrderedDict, iterable
+from .collections import ListCollection, iterable
 from .bunch import Bunch, bunchify
+from collections import OrderedDict
 
 
 class InvalidFieldType(TException):
@@ -441,7 +442,7 @@ class TypedStructMeta(type):
         return cls
 
 
-class _TypedStructDslDict(PythonOrderedDict):
+class _TypedStructDslDict(OrderedDict):
     def __init__(self, bases):
         super().__init__()
         for base in bases:

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -139,3 +139,9 @@ def test_filters_order():
 
     with pytest.raises(AttributeError):
         filterd_l = l.select(lambda o: o.b > 4)
+
+
+def test_simple_object_collection():
+    S = SimpleObjectCollection(L, ID_ATTRIBUTE='id')
+    assert S.get_next(S['5']) == S['6']
+    assert S.get_prev(S['5']) == S['4']


### PR DESCRIPTION
pretty esoteric, i would remove the sibling methods if we could, its too costly...