### PR TITLE
Add `done()` function to `concurrent` to check if the thread is finished

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - units: Added a Percentage class
 - timing: Added a TimeInterval class, for use for timestamp comparisons. Can be converted to/from the Timer class
+- concurrency: Add `done()` function to `concurrent` to check if the thread is finished.
 
 
 ## [0.3.1] - 2019-07-30

--- a/easypy/concurrency.py
+++ b/easypy/concurrency.py
@@ -1021,6 +1021,12 @@ class concurrent(object):
             raise self.exc
         return self._result
 
+    def done(self):
+        """
+        Return ``True`` if the thread is done (successfully or not)
+        """
+        return hasattr(self, '_result') or getattr(self, 'exc', None) is not None
+
     @contextmanager
     def paused(self):
         self.stop()

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -322,3 +322,22 @@ def test_multiexception_types():
 
     with pytest.raises(MultiException[OK]):
         MultiObject([OKBAD]).call(raise_it)
+
+
+@pytest.mark.parametrize('throw', [False, True])
+def test_concurrent_done_status(throw):
+    from threading import Event
+
+    continue_func = Event()
+
+    def func():
+        continue_func.wait()
+        if throw:
+            raise Exception()
+
+    with concurrent(func, throw=False) as c:
+        assert not c.done()
+        continue_func.set()
+        sleep(0.1)
+        assert c.done()
+    assert c.done()


### PR DESCRIPTION
I used `done()` and made it a function instead of property because that's how it looks in `Futures`, but I'm not sure I like that name and if there are other preferences I can change it.