### PR TITLE
Add decorator versions of the various wait functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `ensure_same_defaults` decorator for setting one function's defaults as source of truth for other function
+- Decorator versions of the various wait functions (`waiting`, `iter_waiting`, `waiting_progress` and `iter_waiting_progress`)
 
 ## [0.4.0] - 2019-11-14
 


### PR DESCRIPTION
I've noticed this common pattern:

```python
def foo(self, a, b, c, timeout=60):
    def pred():
	...
    wait(timeout, pred, message=False)
```

These new decorators can be used to remove this boilerplate:
```python
@waiting(timeout=60)
def foo(self, a, b, c):
    ...
```